### PR TITLE
update build depends to work with ghc 8.8

### DIFF
--- a/orgstat.cabal
+++ b/orgstat.cabal
@@ -33,7 +33,7 @@ library
   build-depends:       aeson >= 0.11.2.0
                      , attoparsec
                      , ansi-terminal
-                     , base >=4.11 && <4.12
+                     , base >=4.13 && <4.14
                      , boxes >= 0.1.4
                      , bytestring
                      , colour >= 2.3.3


### PR DESCRIPTION
orgstat seems to work fine with ghc 8.8